### PR TITLE
Add key to userid field

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -17,7 +17,8 @@
         <FIELD NAME="weight" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" PREVIOUS="tree"/>
       </FIELDS>
       <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id" />
+        <KEY NAME="primary" TYPE="primary" FIELDS="id" NEXT="userid"/>
+        <KEY NAME="userid" TYPE="foreign" FIELDS="userid" REFTABLE="user" REFFIELDS="id" PREVIOUS="primary"/>
       </KEYS>
     </TABLE>
 

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -54,6 +54,19 @@ function xmldb_block_sharing_cart_upgrade($oldversion = 0)
 		$table = new xmldb_table('sharing_cart_plugins');
 		$dbman->rename_table($table, 'block_sharing_cart_plugins');
 	}
-	
+
+	if ($oldversion < 2016032900) {
+
+		// Define key userid (foreign) to be added to block_sharing_cart.
+		$table = new xmldb_table('block_sharing_cart');
+		$key   = new xmldb_key('userid', XMLDB_KEY_FOREIGN, array('userid'), 'user', array('id'));
+
+		// Launch add key userid.
+		$dbman->add_key($table, $key);
+
+		// Sharing_cart savepoint reached.
+		upgrade_block_savepoint(true, 2016032900, 'sharing_cart');
+	}
+
 	return true;
 }

--- a/version.php
+++ b/version.php
@@ -2,7 +2,7 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version   = 2015061600;
+$plugin->version   = 2016032900;
 $plugin->requires  = 2012062501.00; // Moodle 2.3.1
 $plugin->component = 'block_sharing_cart';
 $plugin->release   = '2.9, release 1';


### PR DESCRIPTION
Tested the upgrade and fresh install.  This should improve DB performance on sites that have high usage of this block.

Note: I would have also added keys to `block_sharing_cart_plugins` table, but it doesn't appear to be used by this plugin.  Maybe it should be deleted?